### PR TITLE
Fixing encoding issue 136

### DIFF
--- a/kexoqsecdh.c
+++ b/kexoqsecdh.c
@@ -83,15 +83,14 @@ kex_ecdh_dec_key_group(struct kex *kex, const struct sshbuf *ec_blob,
 		r = SSH_ERR_ALLOC_FAIL;
 		goto out;
 	}
-	if (ECDH_compute_key(kbuf, klen, dh_pub, key, NULL) != (int)klen ||
-	    BN_bin2bn(kbuf, klen, shared_secret) == NULL) {
+	if (ECDH_compute_key(kbuf, klen, dh_pub, key, NULL) != (int)klen) {
 		r = SSH_ERR_LIBCRYPTO_ERROR;
 		goto out;
 	}
 #ifdef DEBUG_KEXECDH
 	dump_digest("shared secret", kbuf, klen);
 #endif
-	if ((r = sshbuf_put_bignum2(buf, shared_secret)) != 0)
+	if ((r = sshbuf_put(buf, kbuf, klen)) != 0)
 		goto out;
 	*shared_secretp = buf;
 	buf = NULL;


### PR DESCRIPTION
Fixing a interop issue with how the ECDH shared secret is represented before passed as input into the SSH KDF. It should no longer be an `mpint`, it is should be raw data / `byte` array. Btw, that is what OpenSSH does with its X25519+SNTRU PQ-hybrid key exchange method. 

More details in [issue #136](https://github.com/open-quantum-safe/openssh/issues/136)

Patch courtesy of @geedo0 .
